### PR TITLE
feat: 탈퇴한 회원 credentials 삭제 및 /users/me 토큰 기반으로 변경

### DIFF
--- a/src/main/java/com/jeeeun/demo/controller/UserController.java
+++ b/src/main/java/com/jeeeun/demo/controller/UserController.java
@@ -78,8 +78,8 @@ public class UserController {
 
         // SecurityContext 안에서 현재 로그인한 사람의 userId 꺼내기
         Long userId = (Long) SecurityContextHolder.getContext()
-                .getAuthentication()
-                .getPrincipal();
+                    .getAuthentication()
+                    .getPrincipal();
 
         return UserDetailResponse.from(userQueryService.getUserDetail(userId));
 
@@ -89,14 +89,16 @@ public class UserController {
     // 내 정보 수정 (U)
     @Operation(summary = "내 정보 수정", description = "회원 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "수정 성공")
-    @PatchMapping("/users/{userId}")
+    @PatchMapping("/users/me")
     public UserUpdateResponse updateUser(
-            @PathVariable Long userId,
             @Valid @RequestBody UserUpdateRequest request
     ) {
 
-//        request.validate(); 대신 toCommand() 내에서 검증
+        Long userId = (Long) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
 
+        // request.validate(); 대신 toCommand() 내에서 검증
         UserUpdateResult result = userCommandService.updateUser(request.toCommand(userId));
 
         return UserUpdateResponse.from(result);
@@ -105,7 +107,7 @@ public class UserController {
     /*
         HTTP
          ├─ PathVariable(userId)  ← 리소스 식별
-         └─ Request Body            ← 수정 데이터
+         └─ Request Body          ← 수정 데이터
                 ↓
         Controller 에서 합쳐서
                 ↓
@@ -117,11 +119,15 @@ public class UserController {
     // 회원 탈퇴 (D)
     @Operation(summary = "회원 탈퇴", description = "회원을 탈퇴합니다.")
     @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
-    @DeleteMapping("/users/{userId}")
+    @DeleteMapping("/users/me")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteUser(
-            @PathVariable Long userId
     ) {
+
+        Long userId = (Long) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+
         userCommandService.deleteUser(userId);
     }
 

--- a/src/main/java/com/jeeeun/demo/domain/user/UserCredentials.java
+++ b/src/main/java/com/jeeeun/demo/domain/user/UserCredentials.java
@@ -13,7 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "user_credentials")
+@Table(name = "user_credentials",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"identifier", "provider"}))
 public class UserCredentials {
 
     @Id

--- a/src/main/java/com/jeeeun/demo/repository/UserCredentialsRepository.java
+++ b/src/main/java/com/jeeeun/demo/repository/UserCredentialsRepository.java
@@ -1,6 +1,7 @@
 package com.jeeeun.demo.repository;
 
 import com.jeeeun.demo.domain.user.Provider;
+import com.jeeeun.demo.domain.user.User;
 import com.jeeeun.demo.domain.user.UserCredentials;
 import org.aspectj.apache.bcel.classfile.Module;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,6 @@ public interface UserCredentialsRepository extends JpaRepository<UserCredentials
     // 이메일 + 로그인 방식으로 인증 정보 조회
     // ex) 로컬 로그인 : provider = LOCAL, identifier = 이메일
     Optional<UserCredentials> findByIdentifierAndProvider(String identifier, Provider provider);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/jeeeun/demo/service/UserCommandService.java
+++ b/src/main/java/com/jeeeun/demo/service/UserCommandService.java
@@ -122,6 +122,9 @@ public class UserCommandService {
                 .orElseThrow( () -> new BusinessException(ErrorCode.NOT_FOUND_USER));
 
         user.withdraw();
+
+        // 2) credentials 삭제
+        userCredentialsRepository.deleteByUser(user);
     }
 
         /*

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,10 @@ spring:
     open-in-view: false
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
+  security:
+    user:
+      name: none
+      password: none
 
 # https://jerryjerryjerry.tistory.com/121 mysql 세팅
 


### PR DESCRIPTION
### 👷🏻‍♀️ 개요
- 탈퇴 시 UserCredentials 함께 삭제
- /users/me 토큰 기반으로 변경 (조회/수정/탈퇴)
- BusinessException 메시지 null 수정

### 📍 참고
- 관련 브랜치명: `feature/auth-local`